### PR TITLE
New Rankings Total & Breakdown

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -36,7 +36,7 @@ if isRogue then
 end
 PocketMoneyDB[realmName].guildRankings = PocketMoneyDB[realmName].guildRankings or {}
 
-local CURRENT_DB_VERSION = 1
+local CURRENT_DB_VERSION = 1.1
 
 local function UpgradeDatabase()
   if not PocketMoneyDB[realmName][playerName].dbVersion or PocketMoneyDB[realmName][playerName].dbVersion < CURRENT_DB_VERSION then

--- a/PocketMoney.toc
+++ b/PocketMoney.toc
@@ -3,7 +3,7 @@
 ## Notes: Tracks gold made from pickpocketing
 ## Author: Worlds best rogue Indelible@Discord
 ## SavedVariables: PocketMoneyDB
-## Version: 1.1
+## Version: 1.2
 ## X-Credits: LibSerialize by Ross Nichols
 
 ## Made for Wibber, you're welcome.


### PR DESCRIPTION
**Added**
- Local tables rankings and processedPlayers inside UpdateUI function to avoid stale data
- Direct reading of personal data from local database for accurate totals
- Combined total calculation including Raw Gold, Junk Items, and Junkbox Value

**Changed**
- Sorting function now uses total values instead of just gold
- UpdateUI now handles personal data separately from guild data
- Display text shows combined total instead of just gold value
- ProcessUpdate now stores all three value fields (gold, junk, boxValue)

**Removed**
- Global rankings and processedPlayers tables
- Gold-only sorting logic
- Single value display in rankings